### PR TITLE
[버그] 몬스터가 drop한 장비에 대한 메시지를 출력할 때, 런타임 오류가 발생하는 버그

### DIFF
--- a/TextRPGProject/Core/GameManager.cpp
+++ b/TextRPGProject/Core/GameManager.cpp
@@ -286,15 +286,15 @@ Item* GameManager::MakeShopItem(ShopItems index) {
 void GameManager::DropEquip()
 {
 	Equipment* dropEquip = EquipmentManager::GenerateRandomEquipment();
-	character->Equip(dropEquip);
 	ConsoleOutput::ShowDropEquip(*dropEquip);
+	character->Equip(dropEquip);
 }
 
 void GameManager::DropItem()
 {
 	Item* dropItem = ItemManager::GenerateRandomItem();
-	character->GetRandomItem(dropItem);
 	ConsoleOutput::ShowDropItem(*dropItem);
+	character->GetRandomItem(dropItem);
 }
 
 void GameManager::RandomGetItem()

--- a/TextRPGProject/Types/Equipment/EquipmentManager.cpp
+++ b/TextRPGProject/Types/Equipment/EquipmentManager.cpp
@@ -13,7 +13,7 @@ Equipment* EquipmentManager::GenerateRandomEquipment()
     Equipment* dropEquip = nullptr;
 
     if (roll <= 25) {
-        dropEquip = new Sword("나무 검");
+        dropEquip = new Sword("나무검");
     }
     else if (roll <= 50) {
         dropEquip = new Sword("청동검");


### PR DESCRIPTION

## 원인
![image](https://github.com/user-attachments/assets/f0629007-8fee-4fe2-97cb-5d3726e79f4f)

위 코드는 다음과 같은 순서로 돌아갑니다.

- 장비를 생성하고
- 착용하고 (여기에서 dropEquip 포인터를 해제함)
- dropEquip 을 이용해 메시지를 출력


해제한 포인터를 사용해서 문제가 발생했습니다.
순서만 바꾸면 됩니다.


추가로 "나무 검", "나무검" 통일했습니다.