### PR TITLE
[오류수정]공격력 강화 포션 스텟 증가 수치 조정(상점)

### DIFF
--- a/TextRPGProject/Core/GameManager.cpp
+++ b/TextRPGProject/Core/GameManager.cpp
@@ -268,7 +268,7 @@ void GameManager::Shop()
 Item* GameManager::MakeShopItem(ShopItems index) {
 	Item* shopItem = nullptr;
 	int shop_healthRestore = 50;
-	int shop_attackincrease = 4;
+	int shop_attackincrease = 10;
 	switch (index) {
 	case ShopHealthPotion:
 		shopItem = new HealthPotion(shop_healthRestore);


### PR DESCRIPTION
기존
```
Item* GameManager::MakeShopItem(ShopItems index) {
	Item* shopItem = nullptr;
	int shop_healthRestore = 50;
	int shop_attackincrease = 4;
	switch (index) {
	case ShopHealthPotion:
		shopItem = new HealthPotion(shop_healthRestore);
		break;
	case ShopAttackBoost:
		shopItem = new AttackBoost(shop_attackincrease);
		break;
	default: 
		shopItem = nullptr;
		break;
	}
	return shopItem;
}
```
![image](https://github.com/user-attachments/assets/8658f08d-cc1e-479d-ad97-6c4775a88d0b)

위 코드 중 int shop_attackincrease = 4; -> int shop_attackincrease = 10; 으로 변경

![공격력 아이템 상점에서 구매](https://github.com/user-attachments/assets/2fbd6f9d-838c-4d92-9e84-e01afefc7f95)
![상점 구매 아이템 사용](https://github.com/user-attachments/assets/b1caa7a7-4759-40c9-a9ee-108d173e2ae0)
