### PR TITLE
드랍 회복 포션 수치 조정

### DIFF
--- a/TextRPGProject/Types/Item/ItemManager.cpp
+++ b/TextRPGProject/Types/Item/ItemManager.cpp
@@ -13,7 +13,7 @@ Item* ItemManager::GenerateRandomItem()
     Item* dropItem = nullptr;
 
     if (roll <= 50) {
-        dropItem = new HealthPotion(30);
+        dropItem = new HealthPotion(50);
     }
     else{
         dropItem = new AttackBoost(10);


### PR DESCRIPTION
기존 코드
```
#include "ItemManager.h"
#include "HealthPotion.h"
#include "AttackBoost.h"
#include <random>

Item* ItemManager::GenerateRandomItem()
{
    std::random_device rd;
    std::mt19937 gen(rd());
    std::uniform_int_distribution<> dist(1, 100);

    int roll = dist(gen);
    Item* dropItem = nullptr;

    if (roll <= 50) {
        dropItem = new HealthPotion(30);
    }
    else{
        dropItem = new AttackBoost(10);
    }

    return dropItem;
}
```

해당 코드의 dropItem = new HealthPotion(30)을

→ dropItem = new HealthPotion(50)으로 변경하였습니다.